### PR TITLE
feat: 标题画面播放自定义 BGM 和视频

### DIFF
--- a/AquaMai.Mods/Fancy/TitleScreenTweak.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenTweak.cs
@@ -15,23 +15,40 @@ using UnityEngine.Video;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
-    "标题画面视频",
-    en: "Plays custom video on title screen, just like in the good ol' days",
-    zh: "复刻 bud 代之前的标题界面视频动画")]
+    "标题画面调整",
+    en: "Plays custom BGM and/or video on the title screen, and other tweaks",
+    zh: "允许标题画面播放自定义 BGM 和视频，以及其它微调")]
 [EnableGameVersion(24000)]
-public class TitleScreenVideo
+public class TitleScreenTweak
 {
     [ConfigEntry(
-        en: "Title Video / Audio File Path (without file extensions, mp4 video and acb/awb audio are supported)",
-        zh: "标题视音频文件路径，不包括文件后缀名（视频为 mp4 格式，音频为 acb/awb 格式）")]
-    public static readonly string VideoPath = "LocalAssets/DX_title";
+        name: "启用自定义 BGM")]
+    public static readonly bool EnableCustomBGM = true;
 
     [ConfigEntry(
-        en: "Skip the SEGA / All.Net logo when custom title video file is loaded",
-        zh: "自定标题视频成功加载后，跳过 SEGA / All.Net 标志动画")]
+        name: "自定义 BGM 路径",
+        en: "Custom BGM file path, without file extensions, acb/awb audio supported",
+        zh: "自定义标题 BGM 文件路径，路径不包括文件后缀名，音频文件格式须为 acb/awb")]
+    public static readonly string CustomBGMPath = "LocalAssets/DX_title";
+
+    [ConfigEntry(
+        name: "启用自定义视频")]
+    public static readonly bool EnableCustomVideo = false;
+
+    [ConfigEntry(
+        name: "自定义视频路径",
+        en: "Custom video file path, with file extension, mp4 video supported",
+        zh: "自定义标题视频文件路径，路径包括文件后缀名，视频文件格式须为 mp4")]
+    public static readonly string CustomVideoPath = "LocalAssets/DX_title.mp4";
+
+    [ConfigEntry(
+        name: "跳过 Logo 画面",
+        en: "Skip the SEGA / All.Net logo",
+        zh: "跳过 SEGA / All.Net 标志动画")]
     public static readonly bool SkipLogo = false;
 
     [ConfigEntry(
+        name: "隐藏版权信息",
         en: "Hide copyright information on the bottom of the title screen",
         zh: "隐藏标题画面底部的版权信息")]
     public static readonly bool HideCopyright = false;
@@ -45,14 +62,12 @@ public class TitleScreenVideo
     private static int _videoPreparedCount = 0;
     private static bool IsVideoPrepared => _videoPreparedCount >= 2;
 
-    private static bool _isAudioPrepared = false;
+    private static bool _audioPrepared = false;
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(AdvertiseProcess), "OnStart")]
     public static void OnStart_Postfix(AdvertiseMonitor[] ____monitors)
     {
-        var moviePref = Resources.Load<GameObject>("Process/AdvertiseCommercial/AdvertiseCommercialProcess").transform.Find("Canvas/Main/MovieMask").gameObject;
-
         for (int i = 0; i < ____monitors.Length; ++i)
         {
             var monitor = ____monitors[i];
@@ -64,86 +79,100 @@ public class TitleScreenVideo
             // Hide copyright information
             if (HideCopyright)
                 monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/Licence").gameObject.SetActive(false);
-
-            var titleLoop = monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
-
-            // Disable all elements on the original title screen
-            for (int j = 0; j < titleLoop.childCount; ++j)
-            {
-                var obj = titleLoop.GetChild(j).gameObject;
-                if (obj.activeSelf)
-                {
-                    obj.SetActive(false);
-                    _disabledCompoments[i].Add(obj.name);
-                }
-            }
-
-            _movieObjects[i] = UnityEngine.Object.Instantiate(moviePref, titleLoop);
-            _movieObjects[i].GetComponent<SpriteRenderer>().color = new Color(0, 0, 0, 0);
-
-            _videoPlayers[i] = _movieObjects[i].AddComponent<VideoPlayer>();
-            _videoPlayers[i].url = FileSystem.ResolvePath(VideoPath + ".mp4");
-            _videoPlayers[i].playOnAwake = false;
-            _videoPlayers[i].isLooping = false;
-            _videoPlayers[i].renderMode = VideoRenderMode.MaterialOverride;
-            _videoPlayers[i].audioOutputMode = VideoAudioOutputMode.None;
-
-            var movieSprite = _movieObjects[i].transform.Find("Movie").gameObject.GetComponent<SpriteRenderer>();
-
-            _videoPlayers[i].prepareCompleted += (source) =>
-            {
-                // Prevent autoplay
-                source.Pause();
-                source.time = 0;
-
-                // Setting the video player size
-                var vWidth = source.width;
-                var vHeight = source.height;
-
-                var calWidth = vHeight > vWidth ? (1080 * vWidth / vHeight) : 1080;
-                var calHeight = vHeight > vWidth ? 1080 : (1080 * vHeight / vWidth);
-
-                movieSprite.size = new Vector2(calWidth, calHeight);
-
-                Interlocked.Increment(ref _videoPreparedCount);
-            };
-
-            _videoPlayers[i].errorReceived += (source, err) =>
-            {
-                MelonLogger.Error($"[TitleScreenVideo] Failed to load video file: {err}");
-            };
-
-            _videoPlayers[i].Prepare();
-
-            _videoMaterials[i] = new Material(Shader.Find("Sprites/Default"));
-            movieSprite.material = _videoMaterials[i];
-            _videoPlayers[i].targetMaterialRenderer = movieSprite;
         }
 
-        _isAudioPrepared = SoundManager.MusicPrepareForFileName(VideoPath);
-        if (!_isAudioPrepared)
-            MelonLogger.Warning("[TitleScreenVideo] Failed to load audio file, game's default title jingle will be played instead");
+        if (EnableCustomBGM)
+        {
+            _audioPrepared = SoundManager.MusicPrepareForFileName(CustomBGMPath);
+            if (!_audioPrepared)
+                MelonLogger.Warning("[TitleScreenTweak] Failed to load audio file, game's default title jingle will be played instead");
+        }
+
+        if (EnableCustomVideo)
+        {
+            var moviePref = Resources.Load<GameObject>("Process/AdvertiseCommercial/AdvertiseCommercialProcess").transform.Find("Canvas/Main/MovieMask").gameObject;
+
+            for (int i = 0; i < ____monitors.Length; ++i)
+            {
+                var monitor = ____monitors[i];
+
+                var titleLoop = monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
+
+                // Disable all elements on the original title screen
+                for (int j = 0; j < titleLoop.childCount; ++j)
+                {
+                    var obj = titleLoop.GetChild(j).gameObject;
+                    if (obj.activeSelf)
+                    {
+                        obj.SetActive(false);
+                        _disabledCompoments[i].Add(obj.name);
+                    }
+                }
+
+                _movieObjects[i] = UnityEngine.Object.Instantiate(moviePref, titleLoop);
+                _movieObjects[i].GetComponent<SpriteRenderer>().color = new Color(0, 0, 0, 0);
+
+                _videoPlayers[i] = _movieObjects[i].AddComponent<VideoPlayer>();
+                _videoPlayers[i].url = FileSystem.ResolvePath(CustomVideoPath);
+                _videoPlayers[i].playOnAwake = false;
+                _videoPlayers[i].isLooping = false;
+                _videoPlayers[i].renderMode = VideoRenderMode.MaterialOverride;
+                _videoPlayers[i].audioOutputMode = VideoAudioOutputMode.None;
+
+                var movieSprite = _movieObjects[i].transform.Find("Movie").gameObject.GetComponent<SpriteRenderer>();
+
+                _videoPlayers[i].prepareCompleted += (source) =>
+                {
+                    // Prevent autoplay
+                    source.Pause();
+                    source.time = 0;
+
+                    // Setting the video player size
+                    var vWidth = source.width;
+                    var vHeight = source.height;
+
+                    var calWidth = vHeight > vWidth ? (1080 * vWidth / vHeight) : 1080;
+                    var calHeight = vHeight > vWidth ? 1080 : (1080 * vHeight / vWidth);
+
+                    movieSprite.size = new Vector2(calWidth, calHeight);
+
+                    Interlocked.Increment(ref _videoPreparedCount);
+                };
+
+                _videoPlayers[i].errorReceived += (source, err) =>
+                {
+                    MelonLogger.Error($"[TitleScreenTweak] Failed to load video file: {err}");
+                };
+
+                _videoPlayers[i].Prepare();
+
+                _videoMaterials[i] = new Material(Shader.Find("Sprites/Default"));
+                movieSprite.material = _videoMaterials[i];
+                _videoPlayers[i].targetMaterialRenderer = movieSprite;
+            }
+        }
     }
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(AdvertiseProcess), "OnUpdate")]
     public static void OnUpdate_Postfix(AdvertiseProcess.AdvertiseSequence ____state, AdvertiseMonitor[] ____monitors)
     {
-        if (____state == AdvertiseProcess.AdvertiseSequence.TransitionOut && IsVideoPrepared)
+        if (____state == AdvertiseProcess.AdvertiseSequence.TransitionOut)
         {
             for (int i = 0; i < ____monitors.Length; ++i)
             {
-                // Stop yelling "maimai deluxe" I'm tired to hearing it
-                SoundManager.StopVoice(i);
-
-                _videoPlayers[i].Play();
-
-                if (_isAudioPrepared)
+                if (_audioPrepared)
                 {
                     // Stop game's original title music and plays our own
                     SoundManager.StopJingle(i);
                     SoundManager.StartMusic();
+
+                    // Stops the "maimai DX" voice, turns out it'll conflicts with the custom BGM feature
+                    SoundManager.StopVoice(i);
                 }
+
+                if (IsVideoPrepared)
+                    _videoPlayers[i].Play();
             }
         }
     }
@@ -152,7 +181,7 @@ public class TitleScreenVideo
     [HarmonyPatch(typeof(AdvertiseProcess), "LeaveAdvertise")]
     public static void LeaveAdvertise_Postfix()
     {
-        if (_isAudioPrepared)
+        if (_audioPrepared)
         {
             // Stop and unloads title music
             SoundManager.StopMusic();
@@ -187,7 +216,7 @@ public class TitleScreenVideo
 
         // Resets status
         Interlocked.Exchange(ref _videoPreparedCount, 0);
-        _isAudioPrepared = false;
+        _audioPrepared = false;
         _disabledCompoments = [[], []];
     }
 
@@ -204,18 +233,24 @@ public class TitleScreenVideo
     [HarmonyPatch(typeof(AdvertiseMonitor), "IsTitleAnimationEnd")]
     public static bool Monitor_IsTitleAnimationEnd_Prefix(ref bool __result, int ___monitorIndex)
     {
-        if (!IsVideoPrepared)
-            return true;
+        if (IsVideoPrepared)
+        {
+            __result = !_videoPlayers[___monitorIndex].isPlaying && _videoPlayers[___monitorIndex].frame >= (long)_videoPlayers[___monitorIndex].frameCount - 1;
+            return false;
+        }
+        else if (_audioPrepared)
+        {
+            __result = SoundManager.IsEndMusic();
+        }
 
-        __result = !_videoPlayers[___monitorIndex].isPlaying && _videoPlayers[___monitorIndex].frame >= (long) _videoPlayers[___monitorIndex].frameCount - 1;
-        return false;
+        return true;
     }
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(AdvertiseMonitor), "PlayLogo")]
     public static bool Monitor_PlayLogo_Prefix(int ___monitorIndex, GameObject ____eventModeObject, CanvasGroup ___Main)
     {
-        if (!IsVideoPrepared)
+        if (EnableCustomVideo && !IsVideoPrepared)
         {
             // Re-enable original title screen elements if the video is unavailable
             // doing this early so the transition will be less noticable
@@ -226,8 +261,6 @@ public class TitleScreenVideo
                 titleLoop.Find(name).gameObject.SetActive(true);
 
             _disabledCompoments[___monitorIndex] = [];
-
-            return true;
         }
 
         if (!SkipLogo)
@@ -242,7 +275,7 @@ public class TitleScreenVideo
     [HarmonyPatch(typeof(AdvertiseMonitor), "IsLogoAnimationEnd")]
     public static bool Monitor_IsLogoAnimationEnd_Prefix(ref bool __result)
     {
-        if (!IsVideoPrepared || !SkipLogo)
+        if (!SkipLogo)
             return true;
 
         __result = true;

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -1,0 +1,215 @@
+using AquaMai.Config.Attributes;
+using AquaMai.Core.Attributes;
+using AquaMai.Core.Helpers;
+using HarmonyLib;
+using MAI2.Util;
+using Manager;
+using MelonLoader;
+using Monitor;
+using Process;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Video;
+
+namespace AquaMai.Mods.Fancy;
+
+[ConfigSection(
+    "标题画面视频",
+    en: "Plays custom video on title screen, just like in the good ol' days",
+    zh: "复刻 bud 代之前的标题界面视频动画")]
+[EnableGameVersion(24000)]
+public class TitleScreenVideo
+{
+    [ConfigEntry(
+        en: "Title Video / Audio File Path (without file extensions, mp4 video and acb/awb audio are supported)",
+        zh: "标题视音频文件路径，不包括文件后缀名（视频为 mp4 格式，音频为 acb/awb 格式")]
+    private static readonly string VideoPath = "LocalAssets/DX_title";
+
+    private static GameObject[] _movieObjects = new GameObject[2];
+    private static VideoPlayer[] _videoPlayers = new VideoPlayer[2];
+
+    private static List<string>[] _disabledCompoments = [[], []];
+
+    private static bool _isVideoPrepared = false;
+    private static bool _isAudioPrepared = false;
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(AdvertiseProcess), "OnStart")]
+    public static void OnStart_Postfix(AdvertiseMonitor[] ____monitors)
+    {
+        var moviePref = Resources.Load<GameObject>("Process/AdvertiseCommercial/AdvertiseCommercialProcess").transform.Find("Canvas/Main/MovieMask").gameObject;
+
+        for (int i = 0; i < ____monitors.Length; ++i)
+        {
+            var monitor = ____monitors[i];
+
+            // Disable fade out cover on cir (and maybe future version?)
+            if (GameInfo.GameVersion >= 26000)
+                monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/out_cover")?.gameObject.SetActive(false);
+
+            var titleLoop = monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
+
+            // Disable all elements on the original title screen
+            for (int j = 0; j < titleLoop.childCount; ++j)
+            {
+                var obj = titleLoop.GetChild(j).gameObject;
+                if (obj.activeSelf)
+                {
+                    obj.SetActive(false);
+                    _disabledCompoments[i].Add(obj.name);
+                }
+            }
+
+            _movieObjects[i] = UnityEngine.Object.Instantiate(moviePref, titleLoop);
+            _movieObjects[i].GetComponent<SpriteRenderer>().color = new Color(0, 0, 0, 0);
+
+            _videoPlayers[i] = _movieObjects[i].AddComponent<VideoPlayer>();
+            _videoPlayers[i].url = FileSystem.ResolvePath(VideoPath + ".mp4");
+            _videoPlayers[i].playOnAwake = false;
+            _videoPlayers[i].isLooping = false;
+            _videoPlayers[i].renderMode = VideoRenderMode.MaterialOverride;
+            _videoPlayers[i].audioOutputMode = VideoAudioOutputMode.None;
+
+            var movieSprite = _movieObjects[i].transform.Find("Movie").gameObject.GetComponent<SpriteRenderer>();
+
+            _videoPlayers[i].prepareCompleted += (source) =>
+            {
+                // Prevent autoplay
+                source.Pause();
+                source.time = 0;
+
+                // Setting the video player size
+                var vWidth = source.width;
+                var vHeight = source.height;
+
+                var calWidth = vHeight > vWidth ? (1080 * vWidth / vHeight) : 1080;
+                var calHeight = vHeight > vWidth ? 1080 : (1080 * vHeight / vWidth);
+
+                movieSprite.size = new Vector2(calWidth, calHeight);
+
+                _isVideoPrepared = true;
+            };
+
+            _videoPlayers[i].errorReceived += (source, err) =>
+            {
+                _isVideoPrepared = false;
+
+                MelonLogger.Error($"[TitleScreenVideo] Failed to load video file: {err}");
+            };
+
+            _videoPlayers[i].Prepare();
+
+            var movieMaterial = new Material(Shader.Find("Sprites/Default"));
+            movieSprite.material = movieMaterial;
+            _videoPlayers[i].targetMaterialRenderer = movieSprite;
+        }
+
+        _isAudioPrepared = SoundManager.MusicPrepareForFileName(VideoPath);
+        if (!_isAudioPrepared)
+            MelonLogger.Warning("[TitleScreenVideo] Failed to load audio file, game's default title jingle will be played instead");
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(AdvertiseProcess), "OnUpdate")]
+    public static void OnUpdate_Postfix(AdvertiseProcess.AdvertiseSequence ____state, AdvertiseMonitor[] ____monitors)
+    {
+        switch (____state)
+        {
+            case AdvertiseProcess.AdvertiseSequence.Logo:
+                // Re-enable original title screen elements if the video is unavailable
+                // yeah calling it early so the switch is unnoticeable
+                if (!_isVideoPrepared)
+                {
+                    for (int i = 0; i < ____monitors.Length; ++i)
+                    {
+                        _movieObjects[i].SetActive(false);
+
+                        var titleLoop = ____monitors[i].transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
+                        foreach (string name in _disabledCompoments[i])
+                            titleLoop.Find(name).gameObject.SetActive(true);
+
+                        _disabledCompoments[i] = [];
+                    }
+                }
+                break;
+            case AdvertiseProcess.AdvertiseSequence.TransitionOut:
+                if (_isVideoPrepared)
+                {
+                    for (int i = 0; i < ____monitors.Length; ++i)
+                    {
+                        // Stop yelling "maimai deluxe" I'm tired to hearing it
+                        SoundManager.StopVoice(i);
+
+                        _videoPlayers[i].Play();
+
+                        if (_isAudioPrepared)
+                        {
+                            // Stop game's original title music and plays our own
+                            SoundManager.StopJingle(i);
+                            SoundManager.StartMusic();
+                        }
+                    }
+                }
+                break;
+        }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(AdvertiseProcess), "LeaveAdvertise")]
+    public static void LeaveAdvertise_Postfix()
+    {
+        if (_isAudioPrepared)
+        {
+            // Stop and unloads title music
+            SoundManager.StopMusic();
+            Singleton<SoundCtrl>.Instance.UnloadCueSheet(1);
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvertiseProcess), "OnRelease")]
+    public static void OnRelease_Prefix(AdvertiseMonitor[] ____monitors)
+    {
+        for (int i = 0; i < ____monitors.Length; ++i)
+        {
+            if (_videoPlayers[i] != null)
+            {
+                _videoPlayers[i].prepareCompleted -= null;
+                _videoPlayers[i].errorReceived -= null;
+                UnityEngine.Object.Destroy(_videoPlayers[i]);
+                _videoPlayers[i] = null;
+            }
+
+            if (_movieObjects[i] != null)
+            {
+                UnityEngine.Object.Destroy(_movieObjects[i]);
+                _movieObjects[i] = null;
+            }
+        }
+
+        // Resets status
+        _isVideoPrepared = false;
+        _isAudioPrepared = false;
+        _disabledCompoments = [[], []];
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvertiseMonitor), "AllStop")]
+    public static bool Monitor_AllStop_Prefix()
+    {
+        // So uhh... When I was testing the feature, this method makes title screen suddently go black before transition
+        // I don't like the sudden cutout so I disabled it, not sure about the side effect or compatibility though
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvertiseMonitor), "IsTitleAnimationEnd")]
+    public static bool Monitor_IsTitleAnimationEnd_Prefix(ref bool __result, int ___monitorIndex)
+    {
+        if (!_isVideoPrepared)
+            return true;
+
+        __result = !_videoPlayers[___monitorIndex].isPlaying && _videoPlayers[___monitorIndex].frame >= (long) _videoPlayers[___monitorIndex].frameCount - 1;
+        return false;
+    }
+}

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -27,6 +27,7 @@ public class TitleScreenVideo
 
     private static GameObject[] _movieObjects = new GameObject[2];
     private static VideoPlayer[] _videoPlayers = new VideoPlayer[2];
+    private static Material[] _videoMaterials = new Material[2];
 
     private static List<string>[] _disabledCompoments = [[], []];
 
@@ -99,8 +100,8 @@ public class TitleScreenVideo
 
             _videoPlayers[i].Prepare();
 
-            var movieMaterial = new Material(Shader.Find("Sprites/Default"));
-            movieSprite.material = movieMaterial;
+            _videoMaterials[i] = new Material(Shader.Find("Sprites/Default"));
+            movieSprite.material = _videoMaterials[i];
             _videoPlayers[i].targetMaterialRenderer = movieSprite;
         }
 
@@ -172,6 +173,12 @@ public class TitleScreenVideo
     {
         for (int i = 0; i < ____monitors.Length; ++i)
         {
+            if (_videoMaterials[i] != null)
+            {
+                UnityEngine.Object.Destroy(_videoMaterials[i]);
+                _videoMaterials[i] = null;
+            }
+
             if (_videoPlayers[i] != null)
             {
                 _videoPlayers[i].prepareCompleted -= null;

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -181,8 +181,6 @@ public class TitleScreenVideo
 
             if (_videoPlayers[i] != null)
             {
-                _videoPlayers[i].prepareCompleted -= null;
-                _videoPlayers[i].errorReceived -= null;
                 UnityEngine.Object.Destroy(_videoPlayers[i]);
                 _videoPlayers[i] = null;
             }

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -23,8 +23,8 @@ public class TitleScreenVideo
 {
     [ConfigEntry(
         en: "Title Video / Audio File Path (without file extensions, mp4 video and acb/awb audio are supported)",
-        zh: "标题视音频文件路径，不包括文件后缀名（视频为 mp4 格式，音频为 acb/awb 格式")]
-    private static readonly string VideoPath = "LocalAssets/DX_title";
+        zh: "标题视音频文件路径，不包括文件后缀名（视频为 mp4 格式，音频为 acb/awb 格式）")]
+    public static readonly string VideoPath = "LocalAssets/DX_title";
 
     private static GameObject[] _movieObjects = new GameObject[2];
     private static VideoPlayer[] _videoPlayers = new VideoPlayer[2];

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -26,6 +26,11 @@ public class TitleScreenVideo
         zh: "标题视音频文件路径，不包括文件后缀名（视频为 mp4 格式，音频为 acb/awb 格式）")]
     public static readonly string VideoPath = "LocalAssets/DX_title";
 
+    [ConfigEntry(
+        en: "Skip the SEGA / All.Net logo when custom title video file is loaded",
+        zh: "自定标题视频成功加载后，跳过 SEGA / All.Net 标志动画")]
+    public static readonly bool SkipLogo = false;
+
     private static GameObject[] _movieObjects = new GameObject[2];
     private static VideoPlayer[] _videoPlayers = new VideoPlayer[2];
     private static Material[] _videoMaterials = new Material[2];
@@ -115,44 +120,22 @@ public class TitleScreenVideo
     [HarmonyPatch(typeof(AdvertiseProcess), "OnUpdate")]
     public static void OnUpdate_Postfix(AdvertiseProcess.AdvertiseSequence ____state, AdvertiseMonitor[] ____monitors)
     {
-        switch (____state)
+        if (____state == AdvertiseProcess.AdvertiseSequence.TransitionOut && IsVideoPrepared)
         {
-            case AdvertiseProcess.AdvertiseSequence.Logo:
-                // Re-enable original title screen elements if the video is unavailable
-                // yeah calling it early so the switch is unnoticeable
-                if (!IsVideoPrepared)
+            for (int i = 0; i < ____monitors.Length; ++i)
+            {
+                // Stop yelling "maimai deluxe" I'm tired to hearing it
+                SoundManager.StopVoice(i);
+
+                _videoPlayers[i].Play();
+
+                if (_isAudioPrepared)
                 {
-                    for (int i = 0; i < ____monitors.Length; ++i)
-                    {
-                        _movieObjects[i].SetActive(false);
-
-                        var titleLoop = ____monitors[i].transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
-                        foreach (string name in _disabledCompoments[i])
-                            titleLoop.Find(name).gameObject.SetActive(true);
-
-                        _disabledCompoments[i] = [];
-                    }
+                    // Stop game's original title music and plays our own
+                    SoundManager.StopJingle(i);
+                    SoundManager.StartMusic();
                 }
-                break;
-            case AdvertiseProcess.AdvertiseSequence.TransitionOut:
-                if (IsVideoPrepared)
-                {
-                    for (int i = 0; i < ____monitors.Length; ++i)
-                    {
-                        // Stop yelling "maimai deluxe" I'm tired to hearing it
-                        SoundManager.StopVoice(i);
-
-                        _videoPlayers[i].Play();
-
-                        if (_isAudioPrepared)
-                        {
-                            // Stop game's original title music and plays our own
-                            SoundManager.StopJingle(i);
-                            SoundManager.StartMusic();
-                        }
-                    }
-                }
-                break;
+            }
         }
     }
 
@@ -216,6 +199,44 @@ public class TitleScreenVideo
             return true;
 
         __result = !_videoPlayers[___monitorIndex].isPlaying && _videoPlayers[___monitorIndex].frame >= (long) _videoPlayers[___monitorIndex].frameCount - 1;
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvertiseMonitor), "PlayLogo")]
+    public static bool Monitor_PlayLogo_Prefix(int ___monitorIndex, GameObject ____eventModeObject, CanvasGroup ___Main)
+    {
+        if (!IsVideoPrepared)
+        {
+            // Re-enable original title screen elements if the video is unavailable
+            // doing this early so the transition will be less noticable
+            _movieObjects[___monitorIndex].SetActive(false);
+
+            var titleLoop = ___Main.transform.Find("UI_ADV_Title/Null_all/TitleLoop");
+            foreach (string name in _disabledCompoments[___monitorIndex])
+                titleLoop.Find(name).gameObject.SetActive(true);
+
+            _disabledCompoments[___monitorIndex] = [];
+
+            return true;
+        }
+
+        if (!SkipLogo)
+            return true;
+
+        ____eventModeObject.SetActive(GameManager.IsEventMode);
+        ___Main.transform.Find("UI_ADV_SegaAllNet").gameObject.SetActive(false);
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvertiseMonitor), "IsLogoAnimationEnd")]
+    public static bool Monitor_IsLogoAnimationEnd_Prefix(ref bool __result)
+    {
+        if (!IsVideoPrepared || !SkipLogo)
+            return true;
+
+        __result = true;
         return false;
     }
 }

--- a/AquaMai.Mods/Fancy/TitleScreenVideo.cs
+++ b/AquaMai.Mods/Fancy/TitleScreenVideo.cs
@@ -31,6 +31,11 @@ public class TitleScreenVideo
         zh: "自定标题视频成功加载后，跳过 SEGA / All.Net 标志动画")]
     public static readonly bool SkipLogo = false;
 
+    [ConfigEntry(
+        en: "Hide copyright information on the bottom of the title screen",
+        zh: "隐藏标题画面底部的版权信息")]
+    public static readonly bool HideCopyright = false;
+
     private static GameObject[] _movieObjects = new GameObject[2];
     private static VideoPlayer[] _videoPlayers = new VideoPlayer[2];
     private static Material[] _videoMaterials = new Material[2];
@@ -55,6 +60,10 @@ public class TitleScreenVideo
             // Disable fade out cover on cir (and maybe future version?)
             if (GameInfo.GameVersion >= 26000)
                 monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/out_cover")?.gameObject.SetActive(false);
+
+            // Hide copyright information
+            if (HideCopyright)
+                monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/Licence").gameObject.SetActive(false);
 
             var titleLoop = monitor.transform.Find("Canvas/Main/UI_ADV_Title/Null_all/TitleLoop");
 

--- a/AquaMai/configSort.yaml
+++ b/AquaMai/configSort.yaml
@@ -121,6 +121,7 @@
   - Fancy.GamePlay.ReviveFinaleVSlide
   - Fancy.GamePlay.TapInHoldFix
   - Fancy.TrackCamouflage
+  - Fancy.TitleScreenTweak
   - Fancy.ResourcesOverride
   - Fancy.SkipGameResultAnimation
 


### PR DESCRIPTION
## Sourcery 摘要

在标题画面启用自定义视频和音频播放，并提供可配置的回退与呈现选项。

新功能：
- 添加可配置的自定义标题画面视频播放，并支持可选的匹配音频文件。
- 当自定义媒体可用时，允许跳过 SEGA/All.Net 徽标并隐藏标题画面的版权信息。

改进：
- 当自定义视频准备失败时自动恢复原始标题画面，并在离开该画面时清理媒体资源。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持在标题画面上配置自定义音频和视频，同时在自定义媒体不可用时保留原始体验。

新功能：
- 添加可配置的自定义标题画面 BGM 和 MP4 视频播放，并支持可选的匹配音频。
- 添加跳过 SEGA/All.Net 徽标序列以及隐藏标题画面版权信息的选项。

错误修复：
- 当自定义视频准备失败时，回退到原始标题画面。

增强功能：
- 将标题画面流程与自定义媒体播放绑定，并在离开标题画面时清理自定义媒体资源。

维护工作：
- 在配置排序中注册标题画面自定义模组。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable configurable custom audio and video presentation on the title screen while preserving the original experience when custom media is unavailable.

New Features:
- Add configurable custom title-screen BGM and MP4 video playback with optional matching audio.
- Add options to skip the SEGA/All.Net logo sequence and hide title-screen copyright information.

Bug Fixes:
- Fall back to the original title screen when custom video preparation fails.

Enhancements:
- Tie title-screen progression to custom media playback and clean up custom media resources when leaving the title screen.

Chores:
- Register the title-screen customization mod in the configuration ordering.

</details>

</details>